### PR TITLE
Where's my horse: X Offset condition to work out of the box with the base game

### DIFF
--- a/WheresMyHorse/HarmonyPatch.cs
+++ b/WheresMyHorse/HarmonyPatch.cs
@@ -1,6 +1,7 @@
 ﻿using HarmonyLib;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using StardewModdingAPI;
 using StardewValley;
 using StardewValley.Characters;
 
@@ -14,10 +15,14 @@ internal partial class Mod {
             if (__instance.rider != null) return;
             if (Config.OnlyMyHorse && __instance.getOwner() != Game1.player) return;
             if (!EmoteEnabled) return;
-            
-            Vector2 localPosition = __instance.getLocalPosition(Game1.viewport) + 
-                                    new Vector2(Config.OffsetX, Config.OffsetY - 96f);
+
+            float offsetX = Config.OffsetX + (__instance.GetSpriteWidthForPositioning() == 16 ? 0f : 32f);
+            float offsetY = Config.OffsetY - 96f;
+
+            Vector2 localPosition = __instance.getLocalPosition(Game1.viewport) + new Vector2(offsetX, offsetY);
+
             float num = __instance.StandingPixel.Y + 1;
+
             switch (__instance.FacingDirection)
             {
                 case 0:

--- a/WheresMyHorse/manifest.json
+++ b/WheresMyHorse/manifest.json
@@ -1,7 +1,7 @@
 {
   "Name": "Where's My Horse",
   "Author": "temisthem",
-  "Version": "1.0.0",
+  "Version": "1.0.1",
   "Description": "I found my horse.",
   "UniqueID": "tem696969696969.WheresMyHorse",
   "EntryDll": "WheresMyHorse.dll",


### PR DESCRIPTION
Just added a condition that is equivalent to 'is using thin horse feature from horse overhaul'. that way base game users or users of other thin horse mods that don't edit the draw logic don't need to adjust the offset config, but can still adjust it if they want to.

sorry for the unneeded using statement. I had my code cleaner disabled to not mess up your formatting.